### PR TITLE
Fix skillcrush tech term links

### DIFF
--- a/_includes/web/terms.md
+++ b/_includes/web/terms.md
@@ -5,94 +5,94 @@ terms](http://skillcrush.com/terms/) are artfully explained. These are the ones
 you 100% need to know.
 
 <dl>
-<dd><a href="http://www.skillcrush.com/terms/domain.html">Domain</a></dd>
+<dd><a href="http://skillcrush.com/2012/05/14/domain/">Domain</a></dd>
   <dt><p>Ever wonder what that thing in the top of the browser is?</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/pop-imap.html">POP & IMAP</a></dd>
+  <dd><a href="http://skillcrush.com/2012/06/06/pop-and-imap/">POP & IMAP</a></dd>
   <dt><p>POP, IMAP, SMTP Oh My! It's only email, don't be scared.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/api.html">API</a></dd>
+  <dd><a href="http://skillcrush.com/2012/07/04/api-2/">API</a></dd>
   <dt><p>We're building programs that can talk to other programs. Their APIs are their languages. Sort of.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/wysiwyg.html">WYSIWYG</a></dd>
+  <dd><a href="http://skillcrush.com/2012/06/04/wysiwyg/">WYSIWYG</a></dd>
   <dt><p>You can't always get what you want, but sometimes, What You See Is What You Get.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/ipaddress.html">IP Address</a></dd>
+  <dd><a href="http://skillcrush.com/2012/07/03/ip-address-2/">IP Address</a></dd>
   <dt><p>There's no place like 127.0.0.1, there's no place like 0.0.0.0, there's no place like localhost.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/web-server.html">Web Server</a></dd>
+  <dd><a href="http://skillcrush.com/2012/07/03/web-server-2/">Web Server</a></dd>
   <dt><p>Apache, Puma, Unicorn, Thin, IIS, Mongrel, don't be scared, they are just the beasts behind the world wide web.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/bugs.html">Bugs</a></dd>
+  <dd><a href="http://skillcrush.com/2012/04/20/bugs/">Bugs</a></dd>
   <dt><p>The term 'debugging' was coined by <a href="http://en.wikipedia.org/wiki/Grace_Hopper">Grace Hopper</a> when she literally removed a moth from her computer to get it working.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/dns.html">DNS</a></dd>
+  <dd><a href="http://skillcrush.com/2012/04/24/dns/">DNS</a></dd>
   <dt><p>Finally understand how <code><a href="http://74.125.228.4">74.125.228.4</a></code> actually means google.com</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/cloud.html">The Cloud</a></dd>
+  <dd><a href="http://skillcrush.com/2012/04/19/the-cloud/">The Cloud</a></dd>
   <dt><p>It's like instead of your head being in the clouds, it's all your infrastructure.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/command-line.html">Command Line</a></dd>
+  <dd><a href="http://skillcrush.com/2012/05/25/command-line/">Command Line</a></dd>
   <dt><p>Live deep in the nix heartland and become a loving extension of the shell.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/version-control.html">Version Control</a></dd>
+  <dd><a href="http://skillcrush.com/2013/02/11/version-control/">Version Control</a></dd>
   <dt><p>Rule 1. Never lose code. Rule 2. Never lose code.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/grid-systems.html">Grid Systems</a></dd>
+  <dd><a href="http://skillcrush.com/2012/10/11/grid-systems/">Grid Systems</a></dd>
   <dt><p>Just because we're not designers doesn't mean we shouldn't appreciate and respect their grids.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/rails.html">Rails</a></dd>
+  <dd><a href="http://skillcrush.com/2012/05/18/rails/">Rails</a></dd>
   <dt><p>Not liking Ruby on Rails is like not liking parfait.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/cookies.html">Cookies</a></dd>
+  <dd><a href="http://skillcrush.com/2012/05/16/cookies/">Cookies</a></dd>
   <dt><p>There's probably a pun we could come up with, but we take security seriously.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/404-error.html">404 Error</a></dd>
+  <dd><a href="http://skillcrush.com/2012/05/11/404-error/">404 Error</a></dd>
   <dt><p>The web's <a href="http://fruit.gs/404.html">best</a> <a href="https://github.com/404">easter</a> <a href="http://seatgeek.com/404">egg</a>.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/responsive-design.html">Responsive Design</a></dd>
+  <dd><a href="http://skillcrush.com/2012/05/08/responsive-design/">Responsive Design</a></dd>
   <dt><p>Keep your mind like water, but your design should be fluid and screen independent.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/seo.html">SEO</a></dd>
+  <dd><a href="http://skillcrush.com/2012/10/29/seo-2/">SEO</a></dd>
   <dt><p>Despite what you might read, it's basically just black magic, the dark arts, the voodoo that gives traffic.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/hexidecimal.html">Hex</a></dd>
+  <dd><a href="http://skillcrush.com/2012/05/07/hexadecimal/">Hex</a></dd>
   <dt><p>Because green to you might not be green to me. So there's these really specific codes we use for colors.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/ruby.html">Ruby</a></dd>
+  <dd><a href="http://skillcrush.com/2012/05/04/ruby/">Ruby</a></dd>
   <dt><p>The. Best. Programming. Language. Ever. Period. We. Promise.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/cms.html">CMS</a></dd>
+  <dd><a href="http://skillcrush.com/2012/05/01/cms/">CMS</a></dd>
   <dt><p>All applications are basically just content management systems anyway.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/pseudocode.html">Pseudo Code</a></dd>
+  <dd><a href="http://skillcrush.com/2012/05/02/pseudocode/">Pseudo Code</a></dd>
   <dt><p>First learn to express yourself. Then learn to code.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/https.html">HTTPS</a></dd>
+  <dd><a href="http://skillcrush.com/2012/04/27/https/">HTTPS</a></dd>
   <dt><p>Insecure content warnings? HTTP Sniffing? Here's why.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/open-source.html">Open Source</a></dd>
+  <dd><a href="http://skillcrush.com/2012/08/29/open-source-software/">Open Source</a></dd>
   <dt><p>It's sort of impossible for me to quantify the impact open source software has made, but at <a href="http://trends.builtwith.com/Web-Server/Apache">least 64%</a> of the top million websites are powered by it.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/ajax.html">AJAX</a></dd>
+  <dd><a href="http://skillcrush.com/2012/04/18/ajax/">AJAX</a></dd>
   <dt><p>And <a href="http://www.adaptivepath.com/ideas/ajax-new-approach-web-applications">one day in February 2005</a>, the Internet suddenly felt different.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/frontendbackend.html">Frontend / Backend</a></dd>
+  <dd><a href="http://skillcrush.com/2012/04/17/frontend-vs-backend-3/">Frontend / Backend</a></dd>
   <dt><p>What's the difference? Turns out, less and less.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/javascript.html">Javascript</a></dd>
+  <dd><a href="http://skillcrush.com/2012/04/05/javascript/">Javascript</a></dd>
   <dt><p>The most pervasive and ubiquitous programming language since Flash.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/programming-languages.html">Programming</a></dd>
+  <dd><a href="http://skillcrush.com/2012/04/05/programming-languages/">Programming</a></dd>
   <dt><p>It's awesome.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/database.html">Database</a></dd>
+  <dd><a href="http://skillcrush.com/2012/10/21/databases-2/">Database</a></dd>
   <dt><p>Just think Excel spreadsheet on crack. Better. We mean better.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/css.html">CSS</a></dd>
+  <dd><a href="http://skillcrush.com/2012/04/03/css/">CSS</a></dd>
   <dt><p>We could never love anyone that didn't appreciate the importance of a separation of content and style.</p></dt>
 
-  <dd><a href="http://www.skillcrush.com/terms/html.html">HTML</a></dd>
+  <dd><a href="http://skillcrush.com/2012/04/02/html/">HTML</a></dd>
   <dt><p>All documents should come in this format.</p></dt>
   </dl>
 <h2 class="clear"></h2>


### PR DESCRIPTION
Skillcrush links were correct in OLD-prework.flatironschool.com

https://github.com/flatiron-school/OLD-prework.flatironschool.com/blob/09b70d50aa3aa832f9aca09565fca9ed8a12d95e/index.html
